### PR TITLE
Bolded the current release

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,4 +8,4 @@ sidebar_label: z/OS Agent
 
 The z/OS LSAM is an OpCon agent that allows OpCon to schedule z/OS jobs within a z/OS environment.
 
-The current version is 20.01.02.
+The current version is **20.01.02**.


### PR DESCRIPTION
Easier for user to immediately see the current version