### PR TITLE
OCAG-804: Note tracked-job restart limitation alongside the workaround

### DIFF
--- a/docs/advanced-features/restarting-jobs.md
+++ b/docs/advanced-features/restarting-jobs.md
@@ -1,5 +1,7 @@
 # Restarting External Jobs through OpCon
 
+A direct restart of a Tracked or Queued job only re-reports the prior completion status. To enable a real restart from OpCon, convert the job type to **Batch** and import its JCL using the procedure below.
+
 Some features of OpCon automated restarts are limited when jobs are restarted by external submission:
 
 - GDG regression option "Absolute" will be converted to "Catalogue Resync"


### PR DESCRIPTION
A direct restart of a Tracked or Queued job only re-reports the prior completion status. Add a one-sentence preamble so the page explains why the convert-to-Batch procedure is needed and reads coherently on its own.